### PR TITLE
Change d3 http to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <link rel="stylesheet" href="css/tipsy.css">
 
         <script src="js/vendor/modernizr-2.8.3-respond-1.4.2.min.js"></script>
-        <script src="http://d3js.org/d3.v3.js"></script>
+        <script src="https://d3js.org/d3.v3.js"></script>
         <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>
     </head>
     <body>


### PR DESCRIPTION
When this page loads on https://googletrends.github.io/SearchInterestCandidates/index.html chrome blocks the unsecure http request preventing d3 from loading and the script from finding d3.
